### PR TITLE
Add missing scope tests

### DIFF
--- a/src/oauth2/scope/builder.rs
+++ b/src/oauth2/scope/builder.rs
@@ -95,8 +95,8 @@ mod tests {
 
     /// Tests initialization & successful building of a new instance of scope builder
     #[test]
-    fn test_scope_builder_new() {
-        ScopeBuilder::new().build();
+    fn test_scope_builder_default() {
+        ScopeBuilder::default().build();
     }
 
     /// Tests that all existing scopes can be built

--- a/src/oauth2/scope/character.rs
+++ b/src/oauth2/scope/character.rs
@@ -130,3 +130,16 @@ impl CharacterScopes {
         self
     }
 }
+
+#[cfg(test)]
+mod character_scopes_tests {
+    use crate::oauth2::scope::CharacterScopes;
+
+    /// Tests initializing a default instance of [`CharacterScopes`]
+    #[test]
+    fn test_character_scopes_default() {
+        let character_scopes = CharacterScopes::default();
+
+        assert_eq!(character_scopes.scopes.len(), 0)
+    }
+}

--- a/src/oauth2/scope/corporation.rs
+++ b/src/oauth2/scope/corporation.rs
@@ -152,3 +152,16 @@ impl CorporationScopes {
         self
     }
 }
+
+#[cfg(test)]
+mod corporation_scopes_tests {
+    use crate::oauth2::scope::CorporationScopes;
+
+    /// Tests initializing a default instance of [`CorporationScopes`]
+    #[test]
+    fn test_corporation_scopes_default() {
+        let corporation_scopes = CorporationScopes::default();
+
+        assert_eq!(corporation_scopes.scopes.len(), 0)
+    }
+}

--- a/src/oauth2/scope/wallet.rs
+++ b/src/oauth2/scope/wallet.rs
@@ -41,3 +41,16 @@ impl WalletScopes {
         self
     }
 }
+
+#[cfg(test)]
+mod wallet_scopes_tests {
+    use crate::oauth2::scope::WalletScopes;
+
+    /// Tests initializing a default instance of [`WalletScopes`]
+    #[test]
+    fn test_wallet_scopes_default() {
+        let wallet_scopes = WalletScopes::default();
+
+        assert_eq!(wallet_scopes.scopes.len(), 0)
+    }
+}


### PR DESCRIPTION
Adds missing unit tests for OAuth2 scope builders. These tests are fairly basic, simply ensuring the proper initialization of the builders, their actual ergonomics are tested more so in the endpoints and endpoint integration tests. llvm-cov does not pick up on that since endpoints and their related tests are created through function building macros. So, to ensure full coverage, these unit tests check to ensure all methods can be utilized without issue through invocation of the `ScopeBuilder::all()` method which internally uses every available scope method before building them into a `Vec<String>`.