### PR TITLE
fix(universe): rename corporation_d to corporation_id and derive Clone for Faction (fixes #55)

### DIFF
--- a/src/model/universe.rs
+++ b/src/model/universe.rs
@@ -16,11 +16,11 @@ use serde::{Deserialize, Serialize};
 /// Represents an NPC faction in EVE Online
 ///
 /// # Documentation
-///- <https://developers.eveonline.com/api-explorer#/schemas/UniverseFactionsGet>
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+/// - <https://developers.eveonline.com/api-explorer#/schemas/UniverseFactionsGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Faction {
     /// Primary corporation ID for the faction if applicable
-    pub corporation_d: Option<i64>,
+    pub corporation_id: Option<i64>,
     /// Description for the faction
     pub description: String,
     /// Unique ID of the faction


### PR DESCRIPTION
## Summary  
Renames the incorrectly named `corporation_d` field to `corporation_id` in the `Faction` model and derives the `Clone` trait for the model.  

## Motivation  
Issue #55 reported a typo in the `Faction` struct where the primary corporation ID field was named `corporation_d` instead of `corporation_id`, causing compile errors or runtime issues when using this field. Additionally, models did not implement the `Clone` trait, causing difficulties in unit tests that require cloning models. This PR addresses the field name typo and implements `Clone` for the `Faction` model as a first step towards solving issue #56.  

## Approach  
- Updated `src/model/universe.rs`:  
  - Added `Clone` to the derive list for the `Faction` struct.  
  - Renamed the `corporation_d` field to `corporation_id` and updated doc comment accordingly.  
- Added sign-off and commit message following project's guidelines.  
- The rest of the models will be updated in a separate PR to fully address issue #56.  

## Linked Issue  
Fixes #55